### PR TITLE
Snaphot Export for Amazon Aurora DB

### DIFF
--- a/assets/exporter/main.py
+++ b/assets/exporter/main.py
@@ -45,7 +45,7 @@ def handler(event, context):
             ExportTaskIdentifier=(
                 (message["Source ID"][4:27] + '-').replace("--", "-") + event["Records"][0]["Sns"]["MessageId"]
             ),
-            SourceArn=f"arn:aws:rds:{os.environ['AWS_REGION']}:{account_id}:snapshot:{message['Source ID']}",
+            SourceArn=f"arn:aws:rds:{os.environ['AWS_REGION']}:{account_id}:{os.environ['DB_SNAPSHOT_TYPE']}:{message['Source ID']}",
             S3BucketName=os.environ["SNAPSHOT_BUCKET_NAME"],
             IamRoleArn=os.environ["SNAPSHOT_TASK_ROLE"],
             KmsKeyId=os.environ["SNAPSHOT_TASK_KEY"],

--- a/lib/rds-snapshot-export-pipeline-stack.ts
+++ b/lib/rds-snapshot-export-pipeline-stack.ts
@@ -171,8 +171,8 @@ export class RdsSnapshotExportPipelineStack extends cdk.Stack {
     new CfnEventSubscription(this, 'RdsSnapshotEventNotification', {
       snsTopicArn: snapshotEventTopic.topicArn,
       enabled: true,
-      eventCategories: ['creation'],
-      sourceType: 'db-snapshot',
+      eventCategories: props.rdsEventId == RdsEventId.DB_AUTOMATED_AURORA_SNAPSHOT_CREATED ? ['backup'] : ['creation'],
+      sourceType: props.rdsEventId == RdsEventId.DB_AUTOMATED_AURORA_SNAPSHOT_CREATED ? "db-cluster-snapshot" : "db-snapshot",
     });
 
     new Function(this, "LambdaFunction", {
@@ -187,6 +187,7 @@ export class RdsSnapshotExportPipelineStack extends cdk.Stack {
         SNAPSHOT_BUCKET_NAME: bucket.bucketName,
         SNAPSHOT_TASK_ROLE: snapshotExportTaskRole.roleArn,
         SNAPSHOT_TASK_KEY: snapshotExportEncryptionKey.keyArn,
+        DB_SNAPSHOT_TYPE: props.rdsEventId == RdsEventId.DB_AUTOMATED_AURORA_SNAPSHOT_CREATED ? "cluster-snapshot" : "snapshot",
       },
       role: lambdaExecutionRole,
       timeout: cdk.Duration.seconds(30),

--- a/lib/rds-snapshot-export-pipeline-stack.ts
+++ b/lib/rds-snapshot-export-pipeline-stack.ts
@@ -172,7 +172,7 @@ export class RdsSnapshotExportPipelineStack extends cdk.Stack {
       snsTopicArn: snapshotEventTopic.topicArn,
       enabled: true,
       eventCategories: props.rdsEventId == RdsEventId.DB_AUTOMATED_AURORA_SNAPSHOT_CREATED ? ['backup'] : ['creation'],
-      sourceType: props.rdsEventId == RdsEventId.DB_AUTOMATED_AURORA_SNAPSHOT_CREATED ? "db-cluster-snapshot" : "db-snapshot",
+      sourceType: props.rdsEventId == RdsEventId.DB_AUTOMATED_AURORA_SNAPSHOT_CREATED ? 'db-cluster-snapshot' : 'db-snapshot',
     });
 
     new Function(this, "LambdaFunction", {


### PR DESCRIPTION
*Issue #10:* DB Snapshot Not Found Error

*Description of changes:*
Added if else logic to change the "snapshot type" when the database type is Amazon Aurora.
This will fix RDSEventSubscription & Snapshot export task as needed for Amazon Aurora Database.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
