### PR TITLE
Fix lambda role principal in key policy

### DIFF
--- a/lib/rds-snapshot-export-pipeline-stack.ts
+++ b/lib/rds-snapshot-export-pipeline-stack.ts
@@ -150,7 +150,7 @@ export class RdsSnapshotExportPipelineStack extends cdk.Stack {
             "Effect": "Allow",
           },
           {
-            "Principal": lambdaExecutionRole.roleArn,
+            "Principal": { "AWS": lambdaExecutionRole.roleArn },
             "Action": [
               "kms:CreateGrant",
               "kms:ListGrants",


### PR DESCRIPTION
I don't know if this is something particular to my setup or something has changed recently,
but without this change I was unable to deploy this stack due to a recurring
`MalformedPolicyDocumentException` failure when creating the KMS key.
